### PR TITLE
Added filename as default class name

### DIFF
--- a/React/Class Component With InjectIntl.sublime-snippet
+++ b/React/Class Component With InjectIntl.sublime-snippet
@@ -3,7 +3,7 @@
 import React, { Component, PropTypes } from 'react';
 import { injectIntl, intlShape } from 'react-intl';
 
-class ${1:Component} extends Component {
+class ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Component}} extends Component {
     static propTypes = {
         intl: intlShape.isRequired,
     };

--- a/React/Class Component.sublime-snippet
+++ b/React/Class Component.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 import React, { Component, PropTypes } from 'react';
 
-class ${1:Component} extends Component {
+class ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Component}} extends Component {
     static propTypes = {
         className: PropTypes.string,
     };

--- a/React/Functional Component With InjectIntl.sublime-snippet
+++ b/React/Functional Component With InjectIntl.sublime-snippet
@@ -3,7 +3,7 @@
 import React, { PropTypes } from 'react';
 import { injectIntl, intlShape } from 'react-intl';
 
-const ${1:Component} = ({ intl }) => {
+const ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Component}} = ({ intl }) => {
     const { formatMessage } = intl;
 
     return (

--- a/React/Functional Component.sublime-snippet
+++ b/React/Functional Component.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 import React, { PropTypes } from 'react';
 
-const ${1:Component} = ({ className }) => {
+const ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Component}} = ({ className }) => {
     return (
         ${2}
     );

--- a/Redux/Action.sublime-snippet
+++ b/Redux/Action.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-export const ${1:action} = (${2:payload}) => ({
+export const ${1:${TM_FILENAME/(.+)\..+|.*/$1/:action}} = (${2:payload}) => ({
     type: ${3:type},
     ${2:payload}
 });

--- a/Redux/Reducer.sublime-snippet
+++ b/Redux/Reducer.sublime-snippet
@@ -8,7 +8,7 @@ const defaultState = {
     ${4:prop},
 };
 
-const ${1:Reducer} = (state = defaultState, action = {}) => {
+const ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Reducer}} = (state = defaultState, action = {}) => {
     switch (action.type) {
         case ${5:type}:
             return {

--- a/Redux/Redux Component.sublime-snippet
+++ b/Redux/Redux Component.sublime-snippet
@@ -18,7 +18,7 @@ const mapStateToProps = ({ state }) => ({
     ${4:prop}: state.${4:prop}
 });
 
-export class ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Component}}~ extends Component {
+export class ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Component}} extends Component {
     render() {
         const {
             ${2:action}

--- a/Redux/Redux Component.sublime-snippet
+++ b/Redux/Redux Component.sublime-snippet
@@ -18,7 +18,7 @@ const mapStateToProps = ({ state }) => ({
     ${4:prop}: state.${4:prop}
 });
 
-export class ${1:Component} extends Component {
+export class ${1:${TM_FILENAME/(.+)\..+|.*/$1/:Component}}~ extends Component {
     render() {
         const {
             ${2:action}


### PR DESCRIPTION
If you create a file named `Foo.js`, and then type `rcc->`, `Foo` will now be the default name suggested.