### PR TITLE
Changing proptypes

### DIFF
--- a/React/Class Component.sublime-snippet
+++ b/React/Class Component.sublime-snippet
@@ -1,6 +1,7 @@
 <snippet>
     <content><![CDATA[
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from "prop-types";
 
 class ${1:Component} extends Component {
     static propTypes = {


### PR DESCRIPTION
Hello, since 15.0 {PropTypes} from React has not been supported. It should be install as a package and import from them, I guess most of your snippets includes these changes. If you like I can change it.